### PR TITLE
Update Version 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "table_formatter"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "colored",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "table_formatter"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Embers-of-the-fire <wangbh533@126.com>"]
 description = "A simple text table formatter written in Rust"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Waiting for report :)
 ### V0.5.1
 
 - Changed the api of formatter, and add a macro wrapper for them.
+- Added documentations.
 
 > If you are using the formatter, you just need to change your `vec!`s into `fmt!`s.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This lib is used to format plain-text table.
 Code:
 
 ```rust
+use itertools::Itertools;
+use table_formatter::{cell, table};
+use table_formatter::table::{Align, Border};
 let table_header = vec![
     cell!("Cell Row").with_width(Some(20)),
     cell!("Left", align = Align::Left).with_width(Some(10)),
@@ -60,7 +63,11 @@ Waiting for report :)
 
 ## Change Log
 
-> I've forgot this, so change-log will start from v0.5.0
+### V0.5.1
+
+- Changed the api of formatter, and add a macro wrapper for them.
+
+> If you are using the formatter, you just need to change your `vec!`s into `fmt!`s.
 
 ### V0.5.0
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,16 @@
+//! Macro definitions.
+
+/// This macro is used to generate a table.
+/// 
+/// When you input two identifiers, this will call [Table::create]. If you add "-"s between identifiers, it will generate a splitter.
+/// You can add `with Border` to add a [Border] definition.
+/// 
+/// If you just input a single expression, this will call [Table::new] directly.
+/// You can also add `border = Border` to give a [Border] definition.
+/// 
+/// [Border]: ../table/struct.Border.html
+/// [Table::create]: ../table/struct.Table.html#method.create
+/// [Table::new]: ../table/struct.Table.html#method.new
 #[macro_export]
 macro_rules! table {
     {$h: ident $(-)+ $d: ident $(with $b: expr)?} => {
@@ -6,14 +19,29 @@ macro_rules! table {
     {$h: ident $d: ident $(with $b: expr)?} => {
         $crate::table::Table::create($h, $d, false)$(.with_border($b))?
     };
-    {$d: ident $(with $b: expr)?} => {
+    {$d: expr $(, border = $b: expr)?} => {
         $crate::table::Table::new($d)$(.with_border($b))?
-    };
-    ($d: expr) => {
-        $crate::table::Table::new($d)
     };
 }
 
+/// This macro is used to generate a table cell.
+/// 
+/// If you input nothing, it will generate [Content::None].
+/// 
+/// If you input "-"s, it will generate [Content::Splitter].
+/// 
+/// If you input an expression, it will generate a new [Content::Text] by calling [Content::new]. You can also add alignment, padding and width definitions.
+/// 
+/// ```rust
+/// # use table_formatter::cell;
+/// # use table_formatter::table::{Align, Padding};
+/// cell!("hello world", align=Align::Left, padding=Padding::NONE);
+/// ```
+/// 
+/// [Content::None]: ../table/enum.Content.html#variant.None
+/// [Content::Splitter]: ../table/enum.Content.html#variant.Splitter
+/// [Content::Text]: ../table/enum.Content.html#variant.Text
+/// [Content::new]: ../table/enum.Content.html#method.new
 #[macro_export]
 macro_rules! cell {
     () => {
@@ -27,6 +55,23 @@ macro_rules! cell {
     };
 }
 
+/// This macro is used to wrap those formatters.
+/// 
+/// Since the formatters use both closures and functions, and that two types are not capable with each other, the lib uses a enum(FormatterFunc) to combine them together.
+/// 
+/// This macro will automatically convert any function pointers and closures to a `Rc<Box<dyn Fn(...) -> ...>>`, generating [FormatterFunc::Boxed].
+/// 
+/// You can just use it as the way you use the `vec!` macro.
+/// 
+/// ```rust
+/// # use table_formatter::fmt;
+/// # use colored::Colorize;
+/// let (r, g, b) = (100, 20, 70);
+/// fmt!(Colorize::blue, move |s| s.truecolor(r, g, b));
+/// ```
+/// 
+/// [FormatterFunc::Boxed]: ../table/enum.FormatterFunc.html#variant.Boxed
+/// [FormatterFunc]: ../table/enum.FormatterFunc.html
 #[macro_export]
 macro_rules! fmt {
     () => {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -27,15 +27,34 @@ macro_rules! cell {
     };
 }
 
+#[macro_export]
+macro_rules! fmt {
+    () => {
+        vec![]
+    };
+    ($func: expr) => {
+        vec![$crate::table::FormatterFunc::Boxed(std::rc::Rc::new(Box::new($func)))]
+    };
+    ($($func: expr),+ $(,)?) => {
+        vec![$($crate::table::FormatterFunc::Boxed(std::rc::Rc::new(Box::new($func))), )*]
+    }
+}
+
 #[test]
 fn test_table_macro() {
+    use colored::{Colorize, ColoredString};
+
     use crate::table::Align;
     use crate::table::Border;
 
+    let (r, g, b) = (100, 0, 0);
     let dat1 = vec![cell!("left"), cell!("right", align = Align::Right)];
     let dat2 = vec![
         vec![cell!(-), cell!()],
-        vec![cell!("1"), cell!("2", align = Align::Right)],
+        vec![
+            cell!("1"),
+            cell!("2", align = Align::Right).with_formatter(fmt!(move |s: ColoredString| s.truecolor(r, g, b), Colorize::blue)),
+        ],
     ];
     let table = table! {dat1 - dat2 with Border::ALL};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Error definitions.
+
 use std::io;
 
 use thiserror::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,90 @@
+//! This library is designed to render text tables with possible formatting.
+//!
+//! There is only one entry point to this library, the [Table] struct.
+//!
+//! # How to use
+//!
+//! ## Basic Usage
+//!
+//! You can use the macros to quickly create a table.
+//!
+//! ```rust
+//! use itertools::Itertools;
+//! use table_formatter::{cell, table};
+//! use table_formatter::table::{Align, Border};
+//! let table_header = vec![
+//!     cell!("Cell Row").with_width(Some(20)),
+//!     cell!("Left", align = Align::Left).with_width(Some(10)),
+//!     cell!("Center", align = Align::Center).with_width(Some(10)),
+//!     cell!("Right", align = Align::Right).with_width(Some(10)),
+//! ];
+//! let table_cells = {
+//!     let mut v = (0..=3_u8)
+//!         .map(|_| {
+//!             vec![
+//!                 cell!("Cell Row"),
+//!                 cell!("Left", align = Align::Left),
+//!                 cell!("Center", align = Align::Center),
+//!                 cell!("Right", align = Align::Right),
+//!             ]
+//!         })
+//!         .collect_vec();
+//!     v.push(cell!("Cross Cell!", align = Align::Center).with_span(3));
+//!     v
+//! };
+//! let table = table! {
+//!     table_header
+//!     ---
+//!     table_cells
+//!     with Border::ALL
+//! };
+//! let mut buffer = vec![];
+//! table.render(&mut buffer).unwrap();
+//! println!("{}", String::from_utf8(buffer).unwrap());
+//! ```
+//!
+//! ## Output Definition
+//!
+//! You can use [table::Renderer] to define the way it renders.
+//!
+//! For example, such code below could generate a markdown table.
+//!
+//! ```rust
+//! # use itertools::Itertools;
+//! # use table_formatter::table::{Align, Border, Renderer};
+//! # use table_formatter::{cell, table};
+//! let table_header = vec![
+//!     cell!("Cell Row").with_width(Some(20)),
+//!     cell!("Right", align = Align::Right).with_width(Some(10)),
+//! ];
+//! let table_cells = (0..=3_u8)
+//!     .map(|_| vec![cell!("Cell Row"), cell!("Right", align = Align::Right)])
+//!     .collect_vec();
+//! let table = table! {
+//!     table_header
+//!     ---
+//!     table_cells
+//!     with Border::ALL
+//! };
+//! let mut buffer = vec![];
+//! table.rendered_by(Renderer::Markdown, &mut buffer).unwrap();
+//! println!("{}", String::from_utf8(buffer).unwrap());
+//! ```
+//! 
+//! Output:
+//! ```markdown
+//! |Cell Row|Right|
+//! |:--|--:|
+//! |───|───|
+//! |Cell Row|Right|
+//! |Cell Row|Right|
+//! |Cell Row|Right|
+//! |Cell Row|Right|
+//! ```
+//!
+//! [table::Renderer]: ../table/enum.Renderer.html
+//! [Table]: ../table/struct.Table.html
+
+pub mod builder;
 pub mod error;
 pub mod table;
-pub mod builder;

--- a/src/table/cell.rs
+++ b/src/table/cell.rs
@@ -4,6 +4,14 @@ use crate::table::{Align, Content, Overflow, Padding};
 
 use super::FormatterFunc;
 
+/// Basic item for rendering a table.
+/// 
+/// ```rust
+/// # use table_formatter::table::Cell;
+/// # use table_formatter::table::Content;
+/// // This will create a cell with text "hello world".
+/// Cell::default().with_content(Content::new("hello world"));
+/// ```
 #[derive(Clone, Default)]
 pub struct Cell {
     content: Content,
@@ -77,6 +85,17 @@ impl Cell {
         self
     }
 
+    /// Automatically generate a cross-cell item.
+    /// 
+    /// Using `with_span(x)` will generate a vector with the cell *itself* and **x** empty cells.
+    /// 
+    /// ```rust
+    /// # use table_formatter::table::{Cell, Content};
+    /// let cells = Cell::default().with_content(Content::new("hello world")).with_span(3);
+    /// assert_eq!(cells[0].get_merge(), Some(3));
+    /// assert_eq!(cells.len(), 4);
+    /// assert!(matches!(cells[1].get_content(), Content::None))
+    /// ```
     pub fn with_span(mut self, span: usize) -> Vec<Self> {
         self.set_merge(Some(span));
         self.set_width(None);

--- a/src/table/cell.rs
+++ b/src/table/cell.rs
@@ -2,7 +2,9 @@ use colored::ColoredString;
 
 use crate::table::{Align, Content, Overflow, Padding};
 
-#[derive(Debug, Clone, Default)]
+use super::FormatterFunc;
+
+#[derive(Clone, Default)]
 pub struct Cell {
     content: Content,
     overflow: Overflow,
@@ -10,7 +12,7 @@ pub struct Cell {
     align: Align,
     padding: Padding,
     merge: Option<usize>,
-    formatter: Vec<fn(ColoredString) -> ColoredString>,
+    formatter: Vec<FormatterFunc>,
 }
 
 impl Cell {
@@ -39,7 +41,7 @@ impl Cell {
         self.merge = merge;
         self
     }
-    pub fn with_formatter(mut self, formatter: Vec<fn(ColoredString) -> ColoredString>) -> Self {
+    pub fn with_formatter(mut self, formatter: Vec<FormatterFunc>) -> Self {
         self.formatter = formatter;
         self
     }
@@ -63,17 +65,14 @@ impl Cell {
     pub fn set_merge(&mut self, merge: Option<usize>) {
         self.merge = merge;
     }
-    pub fn set_formatter(mut self, formatter: Vec<fn(ColoredString) -> ColoredString>) {
+    pub fn set_formatter(mut self, formatter: Vec<FormatterFunc>) {
         self.formatter = formatter;
     }
 
-    pub fn append_formatter(&mut self, formatter: &mut Vec<fn(ColoredString) -> ColoredString>) {
+    pub fn append_formatter(&mut self, formatter: &mut Vec<FormatterFunc>) {
         self.formatter.append(formatter);
     }
-    pub fn with_appended_formatter(
-        mut self,
-        formatter: &mut Vec<fn(ColoredString) -> ColoredString>,
-    ) -> Self {
+    pub fn with_appended_formatter(mut self, formatter: &mut Vec<FormatterFunc>) -> Self {
         self.formatter.append(formatter);
         self
     }
@@ -128,7 +127,9 @@ impl Cell {
         let result = self.render_with_width_raw(width);
         self.formatter
             .iter()
-            .fold(ColoredString::from(result.as_str()), |acc, func| func(acc))
+            .fold(ColoredString::from(result.as_str()), |acc, func| {
+                func.run(acc)
+            })
     }
 }
 

--- a/src/table/content.rs
+++ b/src/table/content.rs
@@ -1,5 +1,17 @@
 use super::Overflow;
 
+/// Any possible content in a cell.
+/// 
+/// - Text(String): pure text.
+/// - Splitter: horizontal splitter. Looks like "─".
+/// - None: empty content.
+/// 
+/// ```rust
+/// # use table_formatter::table::Content;
+/// // You can use a string to create one.
+/// assert_eq!(<&str as Into<Content>>::into("123").get_content(), Content::Text("123".to_string()).get_content());
+/// assert_eq!(Content::new("123").get_content(), Content::Text("123".to_string()).get_content());
+/// ```
 #[derive(Debug, Clone, Default)]
 pub enum Content {
     Text(String),
@@ -79,6 +91,13 @@ impl Content {
             },
             Self::Splitter => ("─".repeat(width), width),
             Self::None => (" ".repeat(width), width),
+        }
+    }
+
+    pub fn get_content(&self) -> Option<&String> {
+        match self {
+            Self::Text(ref t) => Some(t),
+            _ => None
         }
     }
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,3 +1,5 @@
+//! Core library and the main entry point.
+
 mod cell;
 mod content;
 mod settings;
@@ -12,6 +14,12 @@ pub use content::*;
 pub use settings::*;
 pub use table::*;
 
+/// Wrapper for formatting-functions.
+/// 
+/// All functions could be converted to [Normal::Boxed], if you don't care about performance, try [fmt!] macro.
+/// 
+/// [fmt!]: ../macro.fmt.html
+/// [Normal::Boxed]: #variant.Boxed
 #[derive(Clone)]
 pub enum FormatterFunc {
     Normal(fn(ColoredString) -> ColoredString),

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -4,7 +4,25 @@ mod settings;
 #[allow(clippy::module_inception)]
 mod table;
 
+use std::rc::Rc;
+
 pub use cell::*;
+use colored::ColoredString;
 pub use content::*;
 pub use settings::*;
 pub use table::*;
+
+#[derive(Clone)]
+pub enum FormatterFunc {
+    Normal(fn(ColoredString) -> ColoredString),
+    Boxed(Rc<Box<dyn Fn(ColoredString) -> ColoredString>>),
+}
+
+impl FormatterFunc {
+    fn run(&self, s: ColoredString) -> ColoredString {
+        match self {
+            FormatterFunc::Normal(f) => f(s),
+            FormatterFunc::Boxed(f) => f(s),
+        }
+    }
+}

--- a/src/table/settings.rs
+++ b/src/table/settings.rs
@@ -1,3 +1,8 @@
+/// Overflow setting for cells.
+/// 
+/// `Overflow::Ellipsis`: "hello world" -> "he..."
+///
+/// `Overflow::Hidden`: "hello" -> "hello"
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Overflow {
     Ellipsis,
@@ -10,6 +15,7 @@ impl Default for Overflow {
     }
 }
 
+/// Text alignment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Align {
     Left,
@@ -23,6 +29,9 @@ impl Default for Align {
     }
 }
 
+/// Padding around the content.
+/// 
+/// A string `"hello"` with `Padding{ left: 1, right: 1 }` will become `" ell "` but not `" hello "`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Padding {
     pub left: usize,
@@ -36,6 +45,7 @@ impl Padding {
     }
 }
 
+/// Border of the table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Border {
     pub left: bool,
@@ -59,9 +69,13 @@ impl Border {
     }
 }
 
+/// Render settings.
 #[derive(Debug, Clone, Copy)]
 pub enum Renderer {
+    /// Render a normal table, with ansi color settings.
     Normal,
+    /// Render a raw table, containing only contents.
     Raw,
+    /// Render a markdown-formatted table. The alignment is determined by **the first row**, and the alignment of the rest of the table will be *ignored*.
     Markdown,
 }

--- a/src/table/table.rs
+++ b/src/table/table.rs
@@ -1,24 +1,38 @@
 use std::io;
 
+use colored::Colorize;
 use itertools::Itertools;
 
 use crate::error::TableError;
 use crate::table::{Align, Border, Cell, Content, Overflow, Renderer};
 
-#[derive(Debug, Clone)]
+use super::FormatterFunc;
+
+#[derive(Clone)]
 pub struct Table {
     table: Vec<Vec<Cell>>,
     border: Border,
 }
 
 impl Table {
-    pub fn create(header: Vec<Cell>, mut cell: Vec<Vec<Cell>>, splitter: bool) -> Table {
+    pub fn create(
+        header: Vec<Cell>,
+        mut cell: Vec<Vec<Cell>>,
+        splitter: bool,
+    ) -> Table {
         let mut v = if splitter {
             let dat = header
                 .iter()
-                .map(|_| Cell::default().with_content(Content::Splitter))
+                .map(|_| {
+                    Cell::default()
+                        .with_content(Content::Splitter)
+                        .with_formatter(vec![FormatterFunc::Normal(Colorize::bold)])
+                })
                 .collect_vec();
-            let mut v = vec![header];
+            let mut v = vec![header
+                .into_iter()
+                .map(|c| c.with_formatter(vec![FormatterFunc::Normal(Colorize::bold)]))
+                .collect_vec()];
             v.push(dat);
             v
         } else {
@@ -173,7 +187,6 @@ impl Table {
     }
 
     pub fn render(&self, writer: &mut impl io::Write) -> Result<(), TableError> {
-        use colored::Colorize;
         let w = self.validate()?;
         let widths = self.update_width(w)?;
         let table_width = widths.iter().map(|v| v + 2).sum::<usize>()

--- a/src/table/table.rs
+++ b/src/table/table.rs
@@ -8,6 +8,9 @@ use crate::table::{Align, Border, Cell, Content, Overflow, Renderer};
 
 use super::FormatterFunc;
 
+/// This is the main entry point of the lib, which represents the table to render.
+///
+/// For more information, please see the lib's documentation.
 #[derive(Clone)]
 pub struct Table {
     table: Vec<Vec<Cell>>,
@@ -15,11 +18,12 @@ pub struct Table {
 }
 
 impl Table {
-    pub fn create(
-        header: Vec<Cell>,
-        mut cell: Vec<Vec<Cell>>,
-        splitter: bool,
-    ) -> Table {
+    /// Create a new table with a header and some rows.
+    ///
+    /// When `splitter` is set to true, this will automatically add a splitter between header and contents.
+    ///
+    /// > This is the recommended way to create a new table, so for details see the lib's documentation.
+    pub fn create(header: Vec<Cell>, mut cell: Vec<Vec<Cell>>, splitter: bool) -> Table {
         let mut v = if splitter {
             let dat = header
                 .iter()
@@ -45,6 +49,7 @@ impl Table {
         }
     }
 
+    /// Create a new table with some rows.
     pub fn new(table: Vec<Vec<Cell>>) -> Table {
         Self {
             table,
@@ -60,6 +65,7 @@ impl Table {
         self.border = border;
     }
 
+    /// This function will overwrite the `overflow` property of every cells in the table.
     pub fn overwrite_overflow(&mut self, overflow: Overflow) {
         for row in self.table.iter_mut() {
             for cell in row.iter_mut() {
@@ -68,6 +74,11 @@ impl Table {
         }
     }
 
+    /// This will render the table according to the render settings. See the lib's documentation for more information.
+    ///
+    /// See [Renderer]
+    ///
+    /// [Renderer]: ../enum.Renderer.html
     pub fn rendered_by(
         &self,
         setting: Renderer,
@@ -80,6 +91,11 @@ impl Table {
         }
     }
 
+    /// This will render a markdown-formatted table.
+    ///
+    /// See also [rendered_by].
+    ///
+    /// [rendered_by]: #method.rendered_by
     pub fn render_markdown(&self, writer: &mut impl io::Write) -> Result<(), TableError> {
         self.validate()?;
         let mut rows = self.table.iter();
@@ -119,6 +135,11 @@ impl Table {
         Ok(())
     }
 
+    /// This will render a raw table without any formatting.
+    ///
+    /// See also [rendered_by].
+    ///
+    /// [rendered_by]: #method.rendered_by
     pub fn render_raw(&self, writer: &mut impl io::Write) -> Result<(), TableError> {
         let w = self.validate()?;
         let widths = self.update_width(w)?;
@@ -186,6 +207,11 @@ impl Table {
         Ok(())
     }
 
+    /// This will render a table with formatting you defined.
+    ///
+    /// See also [rendered_by].
+    ///
+    /// [rendered_by]: #method.rendered_by
     pub fn render(&self, writer: &mut impl io::Write) -> Result<(), TableError> {
         let w = self.validate()?;
         let widths = self.update_width(w)?;
@@ -253,7 +279,7 @@ impl Table {
         Ok(())
     }
 
-    pub fn update_width(&self, w: usize) -> Result<Vec<usize>, TableError> {
+    fn update_width(&self, w: usize) -> Result<Vec<usize>, TableError> {
         let mut v = std::iter::repeat(0).take(w).collect_vec();
         for row in self.table.iter() {
             for (index, cell) in row.iter().enumerate() {
@@ -273,6 +299,9 @@ impl Table {
         Ok(v)
     }
 
+    /// Check if the table is valid. The `usize` represents how many columns the table has.
+    ///
+    /// > This will be automatically checked when rendering, but you could also check it manually before it renders.
     pub fn validate(&self) -> Result<usize, TableError> {
         let mut t = self.table.iter();
         if let Some(v) = t.next() {

--- a/tests/test_doc.rs
+++ b/tests/test_doc.rs
@@ -1,8 +1,8 @@
 #[test]
 fn doc_test() {
     use itertools::Itertools;
-    use table_formatter::{cell, table};
     use table_formatter::table::{Align, Border};
+    use table_formatter::{cell, table};
     let table_header = vec![
         cell!("Cell Row").with_width(Some(20)),
         cell!("Left", align = Align::Left).with_width(Some(10)),
@@ -31,5 +31,28 @@ fn doc_test() {
     };
     let mut buffer = vec![];
     table.render(&mut buffer).unwrap();
+    println!("{}", String::from_utf8(buffer).unwrap());
+}
+
+#[test]
+fn markdown_test() {
+    use itertools::Itertools;
+    use table_formatter::table::{Align, Border, Renderer};
+    use table_formatter::{cell, table};
+    let table_header = vec![
+        cell!("Cell Row").with_width(Some(20)),
+        cell!("Right", align = Align::Right).with_width(Some(10)),
+    ];
+    let table_cells = (0..=3_u8)
+        .map(|_| vec![cell!("Cell Row"), cell!("Right", align = Align::Right)])
+        .collect_vec();
+    let table = table! {
+        table_header
+        ---
+        table_cells
+        with Border::ALL
+    };
+    let mut buffer = vec![];
+    table.rendered_by(Renderer::Markdown, &mut buffer).unwrap();
     println!("{}", String::from_utf8(buffer).unwrap());
 }

--- a/tests/test_doc.rs
+++ b/tests/test_doc.rs
@@ -1,0 +1,35 @@
+#[test]
+fn doc_test() {
+    use itertools::Itertools;
+    use table_formatter::{cell, table};
+    use table_formatter::table::{Align, Border};
+    let table_header = vec![
+        cell!("Cell Row").with_width(Some(20)),
+        cell!("Left", align = Align::Left).with_width(Some(10)),
+        cell!("Center", align = Align::Center).with_width(Some(10)),
+        cell!("Right", align = Align::Right).with_width(Some(10)),
+    ];
+    let table_cells = {
+        let mut v = (0..=3_u8)
+            .map(|_| {
+                vec![
+                    cell!("Cell Row"),
+                    cell!("Left", align = Align::Left),
+                    cell!("Center", align = Align::Center),
+                    cell!("Right", align = Align::Right),
+                ]
+            })
+            .collect_vec();
+        v.push(cell!("Cross Cell!", align = Align::Center).with_span(3));
+        v
+    };
+    let table = table! {
+        table_header
+        ---
+        table_cells
+        with Border::ALL
+    };
+    let mut buffer = vec![];
+    table.render(&mut buffer).unwrap();
+    println!("{}", String::from_utf8(buffer).unwrap());
+}


### PR DESCRIPTION
# V0.5.1

- Changed the api of formatter, and add a macro wrapper for them.
- Added documentations.

> If you are using the formatter, you just need to change your `vec!`s into `fmt!`s.